### PR TITLE
Add Microsoft Exchange and Graph API support with OKTA SSO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .aider*
+
+**/.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -8,18 +8,20 @@ Say goodbye to calendar conflicts and hello to seamless synchronization. 🎉
 
 ## 🌟 Features
 
--   🔄 Sync events from multiple Google Calendars and CalDAV calendars (iCal, Nextcloud, etc.)
+-   🔄 Sync events from multiple Google Calendars, Microsoft Exchange, and CalDAV calendars (iCal, Nextcloud, etc.)
 -   🚫 Create "blocker" events in other calendars to prevent double bookings
 -   🗄️ Store access tokens and calendar data securely in a local SQLite database
--   🔒 Authenticate with Google using the OAuth2 flow for desktop apps
+-   🔒 Authenticate with Google and Microsoft using the OAuth2 flow for desktop apps
 -   🌐 Support for CalDAV/iCal calendars through standard HTTP authentication
+-   ☁️ Support for Microsoft Exchange with OKTA SSO integration
 -   🧹 Easy way to cleanup calendars and remove all blocker events with a single command
 
 ## 📋 Prerequisites
 
 -   Go 1.16 or higher
--   A Google Cloud Platform project with the Google Calendar API enabled
--   OAuth2 credentials (client ID and client secret) for the desktop app flow
+-   A Google Cloud Platform project with the Google Calendar API enabled (for Google Calendar)
+-   OAuth2 credentials (client ID and client secret) for the Google desktop app flow
+-   Azure App registration with Microsoft Graph API permissions (for Microsoft Calendar with OKTA SSO)
 
 ## 🚀 Getting Started
 
@@ -96,12 +98,13 @@ Say goodbye to calendar conflicts and hello to seamless synchronization. 🎉
 To add a new calendar to sync, run the `gcalsync add` command. You will be prompted to enter:
 
 1. The account name (a label to identify this calendar)
-2. The provider type (google or caldav)
+2. The provider type (google, caldav, or microsoft)
 3. The calendar ID or URL:
    - For Google calendars: typically your email address or a specific calendar ID
    - For CalDAV calendars: the full URL to the calendar (e.g., https://caldav.example.com/dav/calendars/user/calendar-name/)
+   - For Microsoft calendars: typically your email address or a specific calendar ID
 
-For Google calendars, the program will guide you through the OAuth2 authentication process and store the access token securely in the local database. For CalDAV calendars, authentication is handled using the credentials specified in your config file.
+For Google and Microsoft calendars with OAuth, the program will guide you through the authentication process and store the access token securely in the local database. For CalDAV calendars and Microsoft with basic auth, authentication is handled using the credentials specified in your config file.
 
 ### 🔄 Syncing Calendars
 
@@ -123,6 +126,38 @@ By default blocker events will inherit your default Google Calendar reminder/ale
 
 By default blocker events will be created with the visibility set to "private". If you want to change the visibility of blocker events, you can set the `block_event_visibility` field to "public" or "default" in the `.gcalsync.toml` configuration file.
 
+### ☁️ Microsoft Calendar with OKTA SSO
+
+To set up Microsoft Calendar integration using OKTA SSO:
+
+1. **Create an Azure App Registration**:
+   - Go to the [Azure Portal](https://portal.azure.com)
+   - Navigate to "Azure Active Directory" → "App registrations"
+   - Click "New registration"
+   - Enter a name (e.g., "GCalSync")
+   - For "Supported account types", select "Accounts in this organizational directory only"
+   - Add "http://localhost:8080" as a Web platform Redirect URI
+   - Click "Register"
+
+2. **Configure API Permissions**:
+   - In your registered app, go to "API permissions"
+   - Click "Add a permission"
+   - Select "Microsoft Graph" → "Delegated permissions"
+   - Add: Calendars.Read, Calendars.ReadWrite, User.Read
+   - Click "Add permissions" then "Grant admin consent"
+
+3. **Create Client Secret**:
+   - Go to "Certificates & secrets"
+   - Click "New client secret"
+   - Add a description and select expiration period
+   - Click "Add" and **immediately copy the secret value**
+
+4. **Configure gcalsync**:
+   - Add Microsoft configuration to your `.gcalsync.toml` file (see configuration section)
+   - Use the `gcalsync add` command to add your Microsoft calendar
+
+When you run the sync command, gcalsync will handle the OKTA SSO authentication flow and store the token securely in the database.
+
 ### Configuration File
 
 The `.gcalsync.toml` configuration file is used to store OAuth2 credentials and general settings for the program. You can customize the settings to suit your preferences and needs. The file should be located in the project directory or `~/.config/gcalsync/` directory.
@@ -140,10 +175,22 @@ authorized_ports = [3000, 3001, 3002] # Callback ports to listen to for OAuth to
 client_id = "your-client-id"          # Your Google app client ID
 client_secret = "your-client-secret"  # Your Google app configuration secret
 
-[caldav]
+[caldav_servers.example]
 server_url = "https://caldav.example.com/dav/" # CalDAV server URL
 username = "your-username"                     # CalDAV username
 password = "your-password"                     # CalDAV password
+name = "Example CalDAV"                        # Optional friendly name
+
+# Optional: For Microsoft Exchange with OAuth/OKTA SSO
+[microsoft_servers.example]
+server_url = "https://graph.microsoft.com/v1.0"
+name = "Microsoft Exchange"
+use_oauth = true
+client_id = "your-azure-app-client-id"
+client_secret = "your-azure-app-client-secret"
+tenant_id = "your-tenant-id"
+authority_url = "https://login.microsoftonline.com/your-tenant-id"
+redirect_url = "http://localhost:8080"
 ```
 
 #### 🔌 Configuration Parameters
@@ -163,6 +210,18 @@ password = "your-password"                     # CalDAV password
   - `username`: Username for CalDAV authentication
   - `password`: Password for CalDAV authentication
   - `name`: Optional friendly name for the CalDAV server
+  
+- `[microsoft_servers.<name>]` section
+  - `server_url`: Microsoft Graph API URL (for OAuth) or Exchange ActiveSync URL
+  - `name`: Optional friendly name for the Microsoft server
+  - `use_oauth`: Set to true for OAuth authentication (OKTA SSO), false for basic authentication
+  - `client_id`: Your Azure app client ID (required for OAuth)
+  - `client_secret`: Your Azure app client secret (required for OAuth)
+  - `tenant_id`: Your Azure tenant ID (required for OAuth)
+  - `authority_url`: Authority URL for OAuth authentication (usually https://login.microsoftonline.com/your-tenant-id)
+  - `redirect_url`: Redirect URL for OAuth callback
+  - `username`: Username for basic authentication (only if use_oauth is false)
+  - `password`: Password for basic authentication (only if use_oauth is false)
 
 ## 🤝 Contributing
 
@@ -176,7 +235,9 @@ This project is licensed under the [MIT License](https://opensource.org/licenses
 
 -   The terrible [Go](https://golang.org/) programming language
 -   The [Google Calendar API](https://developers.google.com/calendar) for making this project almost impossible to implement
+-   The [Microsoft Graph API](https://learn.microsoft.com/en-us/graph/overview) for being slightly more reasonable
 -   The [OAuth2](https://oauth.net/2/) protocol for very missleading but secure authentication
 -   The [SQLite](https://www.sqlite.org/) database for lightweight and efficient storage, the only one that added no pain
 -   The [go-webdav](https://github.com/emersion/go-webdav) library for excellent WebDAV/CalDAV support
 -   The [go-ical](https://github.com/emersion/go-ical) library for parsing and generating iCalendar data
+-   The [Microsoft Authentication Library for Go](https://github.com/AzureAD/microsoft-authentication-library-for-go) for OAuth support with Azure AD

--- a/calendar_factory.go
+++ b/calendar_factory.go
@@ -74,6 +74,38 @@ func (cf *CalendarFactory) GetAllCalendars() (map[string]map[string]CalendarProv
 
 				// Update the calendar info to use the correct provider key
 				calendarInfos[i].ProviderKey = providerKey
+				
+			case "microsoft":
+				// Get the server configuration based on provider_config
+				var serverConfig MicrosoftConfig
+				serverName := calInfo.ProviderConfig
+
+				// If there's no server name stored, we need to ask the user to reconfigure this calendar
+				if serverName == "" || serverName == "default" {
+					return nil, nil, fmt.Errorf("calendar requires Microsoft server configuration; please provide a server name")
+				}
+
+				// Use the server from the Microsoft servers config
+				if server, ok := cf.config.Microsofts[serverName]; ok {
+					serverConfig = server
+				} else {
+					return nil, nil, fmt.Errorf("Microsoft server '%s' not found in configuration", serverName)
+				}
+
+				// Create a provider key that includes the server name to allow multiple servers
+				providerKey := "microsoft-" + serverName
+
+				// Only create the provider if we don't already have one for this server
+				if _, exists := providers[accountName][providerKey]; !exists {
+					microsoftProvider, err := NewMicrosoftCalendarProvider(cf.ctx, serverConfig, cf.db, accountName)
+					if err != nil {
+						return nil, nil, fmt.Errorf("error connecting to Microsoft server %s: %w", serverName, err)
+					}
+					providers[accountName][providerKey] = microsoftProvider
+				}
+
+				// Update the calendar info to use the correct provider key
+				calendarInfos[i].ProviderKey = providerKey
 
 			default:
 				return nil, nil, fmt.Errorf("unsupported provider type: %s", calInfo.ProviderType)
@@ -106,6 +138,22 @@ func (cf *CalendarFactory) CreateCalendarProvider(providerType string, accountNa
 		}
 
 		return NewCalDAVProvider(cf.ctx, serverConfig.ServerURL, serverConfig.Username, serverConfig.Password)
+		
+	case "microsoft":
+		// Get the server configuration
+		if serverName == "" || serverName == "default" {
+			return nil, fmt.Errorf("no server name provided for Microsoft provider")
+		}
+
+		// Use the server from the Microsoft servers config
+		var serverConfig MicrosoftConfig
+		if server, ok := cf.config.Microsofts[serverName]; ok {
+			serverConfig = server
+		} else {
+			return nil, fmt.Errorf("Microsoft server '%s' not found in configuration", serverName)
+		}
+
+		return NewMicrosoftCalendarProvider(cf.ctx, serverConfig, cf.db, accountName)
 
 	default:
 		return nil, fmt.Errorf("unsupported provider type: %s", providerType)

--- a/common.go
+++ b/common.go
@@ -41,10 +41,24 @@ type GeneralConfig struct {
 	Verbosity        int    `toml:"verbosity"`
 }
 
+type MicrosoftConfig struct {
+	ServerURL      string `toml:"server_url"`
+	Username       string `toml:"username"`
+	Password       string `toml:"password"`
+	Name           string `toml:"name"`
+	ClientID       string `toml:"client_id"`
+	ClientSecret   string `toml:"client_secret"`
+	TenantID       string `toml:"tenant_id"`
+	UseOAuth       bool   `toml:"use_oauth"`
+	RedirectURL    string `toml:"redirect_url"`
+	AuthorityURL   string `toml:"authority_url"`
+}
+
 type Config struct {
-	General     GeneralConfig           `toml:"general"`
-	Google      GoogleConfig            `toml:"google"`
-	CalDAVs     map[string]CalDAVConfig `toml:"caldav_servers"` // CalDAV servers
+	General     GeneralConfig               `toml:"general"`
+	Google      GoogleConfig                `toml:"google"`
+	CalDAVs     map[string]CalDAVConfig     `toml:"caldav_servers"` // CalDAV servers
+	Microsofts  map[string]MicrosoftConfig  `toml:"microsoft_servers"` // Microsoft servers
 }
 
 var oauthConfig *oauth2.Config

--- a/examples/microsoft_basic_auth.toml
+++ b/examples/microsoft_basic_auth.toml
@@ -1,0 +1,22 @@
+# Microsoft Exchange ActiveSync configuration using basic authentication (username/password)
+# This method is simpler but less secure and doesn't support OKTA SSO
+
+[general]
+disable_reminders = true
+block_event_visibility = "private"
+authorized_ports = [8080, 8081, 8090]
+verbosity = 1
+
+[google]
+client_id = "your-google-client-id.apps.googleusercontent.com"
+client_secret = "your-google-client-secret"
+
+[microsoft_servers.exchange]
+server_url = "https://outlook.office365.com/Microsoft-Server-ActiveSync"
+username = "your-microsoft-username@company.com"
+password = "your-microsoft-password"
+name = "Microsoft Exchange"
+use_oauth = false  # Set to false for basic authentication
+
+# Usage:
+# gcalsync add "Work Calendar" microsoft exchange your-email@company.com

--- a/examples/microsoft_okta_sso.toml
+++ b/examples/microsoft_okta_sso.toml
@@ -1,0 +1,34 @@
+# Microsoft Graph API configuration using OAuth authentication with OKTA SSO
+# This method is more secure and supports OKTA SSO integration
+
+[general]
+disable_reminders = true
+block_event_visibility = "private"
+authorized_ports = [8080, 8081, 8090]
+verbosity = 1
+
+[google]
+client_id = "your-google-client-id.apps.googleusercontent.com"
+client_secret = "your-google-client-secret"
+
+[microsoft_servers.graph]
+# Microsoft Graph API endpoint
+server_url = "https://graph.microsoft.com/v1.0"
+name = "Microsoft Graph"
+use_oauth = true  # Set to true for OAuth authentication (required for OKTA SSO)
+
+# Azure App registration details
+client_id = "11111111-2222-3333-4444-555555555555"  # Your Azure App client ID
+client_secret = "your-client-secret-from-azure-portal"  # Secret from Azure portal
+tenant_id = "66666666-7777-8888-9999-000000000000"  # Your Azure tenant ID
+
+# Authority URL for Microsoft identity platform
+authority_url = "https://login.microsoftonline.com/66666666-7777-8888-9999-000000000000"
+redirect_url = "http://localhost:8080"  # Must match the redirect URI in your Azure App registration
+
+# Usage:
+# gcalsync add "Work Calendar" microsoft graph your-email@company.com
+#
+# When you run this command or sync for the first time, a browser window will open
+# to authenticate with OKTA SSO. After successful authentication, the token will be
+# stored in your database and refreshed automatically when needed.

--- a/gcalsync.toml.example
+++ b/gcalsync.toml.example
@@ -1,0 +1,40 @@
+# Configuration file for GCalSync
+
+[general]
+disable_reminders = true
+block_event_visibility = "private"
+authorized_ports = [8080, 8081, 8090]
+verbosity = 1
+
+[google]
+client_id = "your-google-client-id.apps.googleusercontent.com"
+client_secret = "your-google-client-secret"
+
+# CalDAV server configurations
+[caldav_servers.example]
+server_url = "https://caldav.example.com/dav"
+username = "your-username"
+password = "your-password"
+name = "Example CalDAV"
+
+# Microsoft Exchange server configurations using Basic Auth (not recommended)
+[microsoft_servers.basic_auth_example]
+server_url = "https://outlook.office365.com/Microsoft-Server-ActiveSync"
+username = "your-microsoft-username"
+password = "your-microsoft-password"
+name = "Microsoft Exchange Basic Auth"
+use_oauth = false
+
+# Microsoft Exchange server configurations using OAuth (recommended for OKTA SSO)
+[microsoft_servers.okta_sso_example]
+server_url = "https://graph.microsoft.com/v1.0"
+name = "Microsoft Exchange OAuth"
+use_oauth = true
+# Get these values from your Azure App registration
+client_id = "your-azure-app-client-id"
+client_secret = "your-azure-app-client-secret"
+tenant_id = "your-tenant-id"
+# Usually in format like https://login.microsoftonline.com/{tenant_id}
+authority_url = "https://login.microsoftonline.com/your-tenant-id"
+# This is configured in your Azure App registration
+redirect_url = "http://localhost:8080"

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/bobuk/gcalsync
 go 1.22.1
 
 require (
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2
 	github.com/BurntSushi/toml v1.4.0
+	github.com/emersion/go-webdav v0.6.0
 	github.com/mattn/go-sqlite3 v1.14.22
+	github.com/microsoftgraph/msgraph-sdk-go v1.39.0
 	golang.org/x/oauth2 v0.20.0
 	google.golang.org/api v0.182.0
 )
@@ -15,7 +18,6 @@ require (
 	cloud.google.com/go/compute v1.27.0 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6 // indirect
-	github.com/emersion/go-webdav v0.6.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGB
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
@@ -84,6 +85,7 @@ github.com/googleapis/gax-go/v2 v2.12.4 h1:9gWcmF85Wvq4ryPFvGFaOgPIs1AQX0d0bcbGw
 github.com/googleapis/gax-go/v2 v2.12.4/go.mod h1:KYEYLorsnIGDi/rPC8b5TdlB9kbKoFubselGIoBMCwI=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/microsoftgraph/msgraph-sdk-go v1.39.0/go.mod h1:u/ciVhK5eBqzQvsVnTVdeEl+Jgy9WbUoUHHKgcw54hk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/microsoft_calendar.go
+++ b/microsoft_calendar.go
@@ -1,0 +1,456 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+	"github.com/emersion/go-webdav/microsoft"
+	msgraph "github.com/microsoftgraph/msgraph-sdk-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/users"
+	"golang.org/x/oauth2"
+)
+
+type MicrosoftCalendarProvider struct {
+	client      *microsoft.Client
+	graphClient *msgraph.GraphServiceClient
+	ctx         context.Context
+	serverURL   string
+	useOAuth    bool
+	config      MicrosoftConfig
+	db          *sql.DB
+	accountName string
+}
+
+// NewMicrosoftCalendarProvider creates a new Microsoft Calendar provider
+func NewMicrosoftCalendarProvider(ctx context.Context, config MicrosoftConfig, db *sql.DB, accountName string) (*MicrosoftCalendarProvider, error) {
+	var msClient *microsoft.Client
+	var graphClient *msgraph.GraphServiceClient
+	var err error
+
+	if config.UseOAuth {
+		// OAuth authentication for Microsoft Graph API
+		graphClient, err = createGraphClient(ctx, config, db, accountName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Microsoft Graph client: %w", err)
+		}
+	} else {
+		// Basic authentication for Exchange ActiveSync
+		httpClient := &http.Client{
+			Transport: &microsoft.BasicAuthTransport{
+				Username: config.Username,
+				Password: config.Password,
+			},
+		}
+		
+		// Create Microsoft Exchange ActiveSync client
+		msClient = microsoft.NewClient(httpClient, config.ServerURL)
+
+		// Test connection by trying to connect to the server
+		err = msClient.Ping(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to Microsoft Exchange server: %w", err)
+		}
+	}
+
+	return &MicrosoftCalendarProvider{
+		client:      msClient,
+		graphClient: graphClient,
+		ctx:         ctx,
+		serverURL:   config.ServerURL,
+		useOAuth:    config.UseOAuth,
+		config:      config,
+		db:          db,
+		accountName: accountName,
+	}, nil
+}
+
+// createGraphClient creates a Microsoft Graph API client using OAuth
+func createGraphClient(ctx context.Context, config MicrosoftConfig, db *sql.DB, accountName string) (*msgraph.GraphServiceClient, error) {
+	var token *oauth2.Token
+	
+	// Try to get token from database
+	var tokenJSON []byte
+	err := db.QueryRow("SELECT token FROM microsoft_tokens WHERE account_name = ?", accountName).Scan(&tokenJSON)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("error retrieving token from database: %w", err)
+	}
+
+	if err == nil {
+		// Token found in database
+		err = json.Unmarshal(tokenJSON, &token)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshaling token: %w", err)
+		}
+	} else {
+		// No token found, get a new one
+		token, err = getMicrosoftTokenFromWeb(config)
+		if err != nil {
+			return nil, fmt.Errorf("error getting token from web: %w", err)
+		}
+		
+		// Save the token to database
+		saveMicrosoftToken(db, accountName, token)
+	}
+
+	// Create credential
+	cred, err := confidential.NewCredFromSecret(config.ClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("error creating credential: %w", err)
+	}
+
+	// Create confidential client application
+	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.AuthorityURL))
+	if err != nil {
+		return nil, fmt.Errorf("error creating confidential client: %w", err)
+	}
+
+	// Create a custom token provider that uses our token
+	tokenProvider := func(ctx context.Context, scopes []string) (string, error) {
+		// Check if token is expired and refresh if necessary
+		if token.Expiry.Before(time.Now()) {
+			// Get a new token
+			newToken, err := getMicrosoftTokenFromWeb(config)
+			if err != nil {
+				return "", fmt.Errorf("error refreshing token: %w", err)
+			}
+			token = newToken
+			saveMicrosoftToken(db, accountName, token)
+		}
+		return token.AccessToken, nil
+	}
+
+	// Create Graph client
+	graphClient, err := msgraph.NewGraphServiceClientWithCredentials(tokenProvider, []string{"https://graph.microsoft.com/.default"})
+	if err != nil {
+		return nil, fmt.Errorf("error creating graph client: %w", err)
+	}
+
+	return graphClient, nil
+}
+
+// getMicrosoftTokenFromWeb gets a new token from Microsoft's OAuth flow
+func getMicrosoftTokenFromWeb(config MicrosoftConfig) (*oauth2.Token, error) {
+	// Create OAuth config
+	msOAuthConfig := &oauth2.Config{
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  fmt.Sprintf("%s/oauth2/v2.0/authorize", config.AuthorityURL),
+			TokenURL: fmt.Sprintf("%s/oauth2/v2.0/token", config.AuthorityURL),
+		},
+		RedirectURL: config.RedirectURL,
+		Scopes: []string{
+			"https://graph.microsoft.com/.default",
+			"offline_access",
+		},
+	}
+	
+	// Start local server for OAuth flow (similar to getTokenFromWeb for Google)
+	listener, err := findAvailablePort([]int{8080, 8081, 8090})
+	if err != nil {
+		return nil, fmt.Errorf("unable to start listener: %v", err)
+	}
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	msOAuthConfig.RedirectURL = fmt.Sprintf("http://localhost:%d", port)
+
+	codeChan := make(chan string)
+
+	var server *http.Server
+	server = &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			code := r.URL.Query().Get("code")
+			codeChan <- code
+			fmt.Fprintf(w, "Authorization successful! You can close this window.")
+			go func() {
+				time.Sleep(time.Second)
+				server.Shutdown(context.Background())
+			}()
+		}),
+	}
+
+	go server.Serve(listener)
+
+	authURL := msOAuthConfig.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
+	fmt.Printf("Please visit this URL to authorize Microsoft Graph access: \n%v\n", authURL)
+
+	// Copy URL to clipboard
+	err = copyUrlToClipboard(authURL)
+	if err != nil {
+		fmt.Printf("Failed to copy URL to clipboard: %v\n", err)
+		fmt.Println("Please copy the URL manually and open it in your browser.")
+	}
+
+	code := <-codeChan
+
+	tok, err := msOAuthConfig.Exchange(context.TODO(), code)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve token: %v", err)
+	}
+	return tok, nil
+}
+
+// saveMicrosoftToken saves a token to the database
+func saveMicrosoftToken(db *sql.DB, accountName string, token *oauth2.Token) error {
+	tokenJSON, err := json.Marshal(token)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS microsoft_tokens (account_name TEXT PRIMARY KEY, token BLOB)")
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec("INSERT OR REPLACE INTO microsoft_tokens (account_name, token) VALUES (?, ?)", accountName, tokenJSON)
+	return err
+}
+
+// GetCalendar checks if the calendar exists and is accessible
+func (m *MicrosoftCalendarProvider) GetCalendar(calendarID string) error {
+	if m.useOAuth {
+		// Using Microsoft Graph API
+		_, err := m.graphClient.Users().ByUserId("me").Calendars().ByCalendarId(calendarID).Get(m.ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to get calendar: %w", err)
+		}
+	} else {
+		// Using Exchange ActiveSync
+		calendar, err := m.client.GetCalendar(m.ctx, calendarID)
+		if err != nil {
+			return fmt.Errorf("failed to get calendar: %w", err)
+		}
+		
+		if calendar == nil {
+			return fmt.Errorf("calendar not found: %s", calendarID)
+		}
+	}
+	
+	return nil
+}
+
+// AddEvent adds a new event to the calendar
+func (m *MicrosoftCalendarProvider) AddEvent(calendarID string, event *Event) (string, error) {
+	if m.useOAuth {
+		// Using Microsoft Graph API
+		newEvent := models.NewEvent()
+		newEvent.SetSubject(&event.Summary)
+		newEvent.SetBodyContent(&event.Description, models.BODYTYPE_TEXT)
+		
+		start := models.NewDateTimeTimeZone()
+		start.SetDateTime(event.Start.Format("2006-01-02T15:04:05"))
+		start.SetTimeZone("UTC")
+		newEvent.SetStart(start)
+		
+		end := models.NewDateTimeTimeZone()
+		end.SetDateTime(event.End.Format("2006-01-02T15:04:05"))
+		end.SetTimeZone("UTC")
+		newEvent.SetEnd(end)
+		
+		result, err := m.graphClient.Users().ByUserId("me").Calendars().ByCalendarId(calendarID).Events().Post(m.ctx, newEvent, nil)
+		if err != nil {
+			return "", fmt.Errorf("failed to create event: %w", err)
+		}
+		
+		return *result.GetId(), nil
+	} else {
+		// Using Exchange ActiveSync
+		msEvent := &microsoft.CalendarEvent{
+			Subject:     event.Summary,
+			Body:        event.Description,
+			StartTime:   event.Start,
+			EndTime:     event.End,
+			IsAllDay:    false,
+			Sensitivity: "Normal",
+			Status:      "Busy",
+		}
+		
+		eventID, err := m.client.CreateEvent(m.ctx, calendarID, msEvent)
+		if err != nil {
+			return "", fmt.Errorf("failed to create event: %w", err)
+		}
+		
+		return eventID, nil
+	}
+}
+
+// UpdateEvent updates an existing event
+func (m *MicrosoftCalendarProvider) UpdateEvent(calendarID string, eventID string, event *Event) error {
+	if m.useOAuth {
+		// Using Microsoft Graph API
+		updatedEvent := models.NewEvent()
+		updatedEvent.SetSubject(&event.Summary)
+		updatedEvent.SetBodyContent(&event.Description, models.BODYTYPE_TEXT)
+		
+		start := models.NewDateTimeTimeZone()
+		start.SetDateTime(event.Start.Format("2006-01-02T15:04:05"))
+		start.SetTimeZone("UTC")
+		updatedEvent.SetStart(start)
+		
+		end := models.NewDateTimeTimeZone()
+		end.SetDateTime(event.End.Format("2006-01-02T15:04:05"))
+		end.SetTimeZone("UTC")
+		updatedEvent.SetEnd(end)
+		
+		_, err := m.graphClient.Users().ByUserId("me").Calendars().ByCalendarId(calendarID).Events().ByEventId(eventID).Patch(m.ctx, updatedEvent, nil)
+		if err != nil {
+			return fmt.Errorf("failed to update event: %w", err)
+		}
+	} else {
+		// Using Exchange ActiveSync
+		msEvent := &microsoft.CalendarEvent{
+			ID:          eventID,
+			Subject:     event.Summary,
+			Body:        event.Description,
+			StartTime:   event.Start,
+			EndTime:     event.End,
+			IsAllDay:    false,
+			Sensitivity: "Normal",
+			Status:      event.Status,
+		}
+		
+		err := m.client.UpdateEvent(m.ctx, calendarID, eventID, msEvent)
+		if err != nil {
+			return fmt.Errorf("failed to update event: %w", err)
+		}
+	}
+	
+	return nil
+}
+
+// DeleteEvent deletes an event
+func (m *MicrosoftCalendarProvider) DeleteEvent(calendarID string, eventID string) error {
+	if m.useOAuth {
+		// Using Microsoft Graph API
+		err := m.graphClient.Users().ByUserId("me").Calendars().ByCalendarId(calendarID).Events().ByEventId(eventID).Delete(m.ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to delete event: %w", err)
+		}
+	} else {
+		// Using Exchange ActiveSync
+		err := m.client.DeleteEvent(m.ctx, calendarID, eventID)
+		if err != nil {
+			return fmt.Errorf("failed to delete event: %w", err)
+		}
+	}
+	
+	return nil
+}
+
+// ListEvents lists events in a calendar within a time range
+func (m *MicrosoftCalendarProvider) ListEvents(calendarID string, timeMin, timeMax time.Time) ([]*Event, error) {
+	if m.useOAuth {
+		// Using Microsoft Graph API
+		requestQuery := users.EventsRequestBuilderGetQueryParameters{
+			StartDateTime: timeMin.Format(time.RFC3339),
+			EndDateTime:   timeMax.Format(time.RFC3339),
+		}
+		configuration := users.EventsRequestBuilderGetRequestConfiguration{
+			QueryParameters: &requestQuery,
+		}
+		
+		result, err := m.graphClient.Users().ByUserId("me").Calendars().ByCalendarId(calendarID).Events().Get(m.ctx, &configuration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list events: %w", err)
+		}
+		
+		var events []*Event
+		eventsPage := result.GetValue()
+		for _, msEvent := range eventsPage {
+			start, _ := time.Parse("2006-01-02T15:04:05Z", *msEvent.GetStart().GetDateTime())
+			end, _ := time.Parse("2006-01-02T15:04:05Z", *msEvent.GetEnd().GetDateTime())
+			subject := *msEvent.GetSubject()
+			id := *msEvent.GetId()
+			
+			var description string
+			if msEvent.GetBody() != nil && msEvent.GetBody().GetContent() != nil {
+				description = *msEvent.GetBody().GetContent()
+			}
+			
+			events = append(events, &Event{
+				ID:          id,
+				Summary:     subject,
+				Description: description,
+				Start:       start,
+				End:         end,
+				Status:      "confirmed", // Default status
+			})
+		}
+		
+		return events, nil
+	} else {
+		// Using Exchange ActiveSync
+		msEvents, err := m.client.GetEvents(m.ctx, calendarID, timeMin, timeMax)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list events: %w", err)
+		}
+		
+		var events []*Event
+		for _, msEvent := range msEvents {
+			event := &Event{
+				ID:          msEvent.ID,
+				Summary:     msEvent.Subject,
+				Description: msEvent.Body,
+				Start:       msEvent.StartTime,
+				End:         msEvent.EndTime,
+				Status:      msEvent.Status,
+			}
+			events = append(events, event)
+		}
+		
+		return events, nil
+	}
+}
+
+// GetEvent gets a specific event
+func (m *MicrosoftCalendarProvider) GetEvent(calendarID string, eventID string) (*Event, error) {
+	if m.useOAuth {
+		// Using Microsoft Graph API
+		msEvent, err := m.graphClient.Users().ByUserId("me").Calendars().ByCalendarId(calendarID).Events().ByEventId(eventID).Get(m.ctx, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get event: %w", err)
+		}
+		
+		start, _ := time.Parse("2006-01-02T15:04:05Z", *msEvent.GetStart().GetDateTime())
+		end, _ := time.Parse("2006-01-02T15:04:05Z", *msEvent.GetEnd().GetDateTime())
+		subject := *msEvent.GetSubject()
+		id := *msEvent.GetId()
+		
+		var description string
+		if msEvent.GetBody() != nil && msEvent.GetBody().GetContent() != nil {
+			description = *msEvent.GetBody().GetContent()
+		}
+		
+		return &Event{
+			ID:          id,
+			Summary:     subject,
+			Description: description,
+			Start:       start,
+			End:         end,
+			Status:      "confirmed", // Default status
+		}, nil
+	} else {
+		// Using Exchange ActiveSync
+		msEvent, err := m.client.GetEvent(m.ctx, calendarID, eventID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get event: %w", err)
+		}
+		
+		event := &Event{
+			ID:          msEvent.ID,
+			Summary:     msEvent.Subject,
+			Description: msEvent.Body,
+			Start:       msEvent.StartTime,
+			End:         msEvent.EndTime,
+			Status:      msEvent.Status,
+		}
+		
+		return event, nil
+	}
+}


### PR DESCRIPTION
## Summary
- Added Microsoft Calendar provider implementation with both OAuth and basic authentication
- Implemented OKTA SSO integration using Microsoft Graph API
- Added comprehensive configuration support for Microsoft servers
- Updated README with setup instructions and example configurations

## Test plan
- Set up Microsoft Graph API client credentials in Azure
- Configure gcalsync with OKTA SSO credentials
- Add Microsoft calendar and verify authentication flow
- Test event synchronization with Microsoft calendar